### PR TITLE
fix: populate g_metric ip/node_id/port in Arranger (non-binlog) mode

### DIFF
--- a/src/arranger/arranger.cpp
+++ b/src/arranger/arranger.cpp
@@ -51,12 +51,22 @@ int Arranger::init()
   return OMS_OK;
 }
 
+void Arranger::init_metric_config()
+{
+  g_metric->set_ip(_localip);
+  g_metric->set_port(_s_conf.service_port.val());
+  g_metric->set_node_id(_localhost);
+}
+
 int Arranger::run_foreground()
 {
   int ret = _accepter.listen(_s_conf.service_port.val());
   if (ret != OMS_OK) {
     return ret;
   }
+
+  init_metric_config();
+
   StatusThread status_thread;
   status_thread.register_gauge("NREADER", [this] { return _client_peers.size(); });
   status_thread.register_gauge("NCHANNEL", [this] { return _accepter.channel_count(); });

--- a/src/arranger/arranger.h
+++ b/src/arranger/arranger.h
@@ -30,6 +30,7 @@ public:
   int run_foreground();
 
 private:
+  void init_metric_config();
   void on_close(const Peer&);
 
   EventResult on_handshake(const Peer&, const Message&);


### PR DESCRIPTION
## Summary
In non-binlog mode (binlog_mode=false), Arranger::run_foreground() never set g_metric's ip/node_id/port, leaving them as empty strings. This caused all prometheus metrics to show host_name="" and ip="".
<img width="1008" height="735" alt="image" src="https://github.com/user-attachments/assets/57a94fa5-90e2-47a8-af59-c7a9a582027f" />


## Solution Description
Set these from _localip, _localhost (already resolved in Arranger::init via gethostname/gethostbyname) and service_port config before starting StatusThread.

@whhe 